### PR TITLE
automatic NOFILE increase, show help at no arg, ...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build
+      - run: cargo test
+      - run: cargo clippy --no-deps -- -D warnings
+      - run: cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -18,16 +18,14 @@ Arguments:
   <PATHS>...  Files to perform jaso merges
 
 Options:
-  -r, --recursive
       --follow-directory-symlinks
   -v, --verbose
       --dry-run
   -h, --help                       Print help
 ```
 
-현재 위치한 디렉토리를 정규화하고 싶으면 `jaso -rv .` 을 하시면 됩니다.
+현재 위치한 디렉토리를 정규화하고 싶으면 `jaso .` 을 하시면 됩니다.
 
-- `-r`: 파일 탐색 중 디렉토리를 만나면 안쪽 파일과 그 안쪽... 까지 모두 정규화를 수행합니다.
 - `-v`: 정규화에 시간이 얼마나 걸렸는지와 같은 정보를 추가로 표시합니다.
 - `--dry-run`: 파일명을 실제로 바꾸지 않고 어떻게 바꿀 것인지 표시만 수행합니다.
 - `--follow-directory-symlinks`: 디렉토리 심링크를 따라갑니다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ const CONCURRENT_TASKS: usize = 32768;
 static SEMA: Semaphore = Semaphore::const_new(CONCURRENT_TASKS);
 
 #[derive(Parser, Debug)]
-#[clap(rename_all = "kebab-case")]
+#[clap(version, rename_all = "kebab-case", arg_required_else_help = true)]
 struct Args {
     #[arg(long)]
     follow_directory_symlinks: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,6 @@ static SEMA: Semaphore = Semaphore::const_new(CONCURRENT_TASKS);
 #[derive(Parser, Debug)]
 #[clap(rename_all = "kebab-case")]
 struct Args {
-    #[arg(short, long)]
-    recursive: bool,
     #[arg(long)]
     follow_directory_symlinks: bool,
     #[arg(short, long)]
@@ -34,8 +32,8 @@ async fn main() {
         eprintln!("warning: NOFILE resource limit is low(={nofile:?}), run ulimit -n 65536 and try again if panic occurs");
     }
 
-    if args.follow_directory_symlinks && args.recursive {
-        eprintln!("warning: --recursive and --follow_directory_symlinks is both ON; be aware for infinite recursion!");
+    if args.follow_directory_symlinks {
+        eprintln!("warning: --follow_directory_symlinks is ON; be aware for infinite recursion!");
     }
 
     let start = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,13 @@ struct Args {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    let nofile = rlimit::getrlimit(Resource::NOFILE).expect("cannot query rlimit");
 
+    // Automatically increase NOFILE rlimit to the allowed maximum
+    rlimit::increase_nofile_limit(u64::MAX).expect("failed during increasing NOFILE rlimit");
+
+    let nofile = rlimit::getrlimit(Resource::NOFILE).expect("cannot query rlimit");
     if nofile.0 < 1024 || nofile.1 < 1024 {
-        eprintln!("warning: NOFILE resource limit is low(={nofile:?}), run ulimit -n 65536 and try again if panic occurs");
+        eprintln!("warning: NOFILE resource limit is low(={nofile:?}), run `ulimit -n 65536` and try again if panic occurs");
     }
 
     if args.follow_directory_symlinks {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ const CONCURRENT_TASKS: usize = 32768;
 static SEMA: Semaphore = Semaphore::const_new(CONCURRENT_TASKS);
 
 #[derive(Parser, Debug)]
-#[clap(version, rename_all = "kebab-case", arg_required_else_help = true)]
+#[clap(version, arg_required_else_help = true)]
 struct Args {
     #[arg(long)]
     follow_directory_symlinks: bool,

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,5 +1,5 @@
 use std::os::unix::prelude::*;
-use std::{fs, io::ErrorKind, process::Command};
+use std::{fs, process::Command};
 
 const DECOMPOSED: &str = "\u{110b}\u{1161}\u{11ab}\u{1102}\u{1167}\u{11bc}\u{1112}\u{1161}\u{1109}\u{1166}\u{110b}\u{116d}";
 const COMPOSED: &str = "안녕하세요";


### PR DESCRIPTION
Behavioral changes:

1. [Automatically increase NOFILE rlimit to the allowed maximum](https://github.com/cr0sh/jaso/commit/e73aecd4c99c7babdd1419182742dd3ebeb96961)
2. [Print help message when no argument is given, add --version option](https://github.com/cr0sh/jaso/commit/ab5c830041c3947ae4a092f230b1f479f5d75223)
3. [Remove unused --recursive option](https://github.com/cr0sh/jaso/commit/85f101cb1e45982740078f797e15356399e1ad47)

Non-behavioral changes:

1. Added CI for tests, clippy, fmt
2. Fixed all clippy warnings (removed unused imports)
3. etc

Closes #3
Closes #4 
