### PR TITLE
Add `-n` as an alias of `--dry-run`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
     follow_directory_symlinks: bool,
     #[arg(short, long)]
     verbose: bool,
-    #[arg(long)]
+    #[arg(short = 'n', long)]
     dry_run: bool,
     /// Files to perform jaso merges
     #[arg(required = true)]


### PR DESCRIPTION
It's common practice to use `-n` as `--dry-run`.